### PR TITLE
Add KM Hospital addon

### DIFF
--- a/odoo_addons/km_hospital/README.md
+++ b/odoo_addons/km_hospital/README.md
@@ -1,0 +1,3 @@
+# KM Hospital
+
+Minimal Odoo 16 addon providing basic hospital management models: departments, doctors, patients, appointments and lab tests.

--- a/odoo_addons/km_hospital/__init__.py
+++ b/odoo_addons/km_hospital/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/odoo_addons/km_hospital/__manifest__.py
+++ b/odoo_addons/km_hospital/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "KM Hospital",
+    "version": "16.0.1.0.0",
+    "license": "LGPL-3",
+    "category": "Healthcare",
+    "summary": "Basic hospital management models",
+    "depends": ["base", "mail"],
+    "data": [
+        "security/ir.model_access.csv",
+        "data/sequence.xml",
+        "views/menu.xml",
+        "views/department_views.xml",
+        "views/doctor_views.xml",
+        "views/patient_views.xml",
+        "views/appointment_views.xml",
+        "views/test_views.xml",
+        "views/test_result_views.xml",
+    ],
+    "application": True,
+}

--- a/odoo_addons/km_hospital/data/sequence.xml
+++ b/odoo_addons/km_hospital/data/sequence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="seq_km_patient" model="ir.sequence">
+    <field name="name">Patient</field>
+    <field name="code">km.patient</field>
+    <field name="prefix">PAT</field>
+    <field name="padding">5</field>
+  </record>
+
+  <record id="seq_km_appointment" model="ir.sequence">
+    <field name="name">Appointment</field>
+    <field name="code">km.appointment</field>
+    <field name="prefix">APT</field>
+    <field name="padding">6</field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/models/__init__.py
+++ b/odoo_addons/km_hospital/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from . import department
+from . import doctor
+from . import patient
+from . import appointment
+from . import test
+from . import test_result

--- a/odoo_addons/km_hospital/models/appointment.py
+++ b/odoo_addons/km_hospital/models/appointment.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class KmAppointment(models.Model):
+    """Patient appointment."""
+
+    _name = "km.appointment"
+    _description = "Appointment"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "datetime_start desc"
+
+    name = fields.Char(readonly=True, copy=False, index=True)
+    patient_id = fields.Many2one("km.patient", string="Patient", required=True)
+    doctor_id = fields.Many2one("km.doctor", string="Doctor", required=True)
+    department_id = fields.Many2one(
+        "km.department", string="Department", compute="_compute_department_id", store=True
+    )
+    datetime_start = fields.Datetime(string="Start", default=fields.Datetime.now, required=True)
+    reason = fields.Text()
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("scheduled", "Scheduled"),
+            ("done", "Done"),
+            ("cancelled", "Cancelled"),
+        ],
+        default="draft",
+        tracking=True,
+    )
+
+    @api.depends("doctor_id")
+    def _compute_department_id(self):
+        for rec in self:
+            rec.department_id = rec.doctor_id.department_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("name"):
+                vals["name"] = self.env["ir.sequence"].next_by_code("km.appointment") or "/"
+        return super().create(vals_list)
+
+    def action_confirm(self):
+        for rec in self:
+            rec.state = "scheduled"
+
+    def action_done(self):
+        for rec in self:
+            rec.state = "done"
+
+    def action_cancel(self):
+        for rec in self:
+            rec.state = "cancelled"

--- a/odoo_addons/km_hospital/models/department.py
+++ b/odoo_addons/km_hospital/models/department.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class KmDepartment(models.Model):
+    """Hospital department."""
+
+    _name = "km.department"
+    _description = "Hospital Department"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    code = fields.Char()
+    description = fields.Text()
+    doctor_ids = fields.One2many("km.doctor", "department_id", string="Doctors")
+    patient_ids = fields.One2many("km.patient", "department_id", string="Patients")

--- a/odoo_addons/km_hospital/models/doctor.py
+++ b/odoo_addons/km_hospital/models/doctor.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class KmDoctor(models.Model):
+    """Medical doctor."""
+
+    _name = "km.doctor"
+    _description = "Doctor"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    code = fields.Char()
+    department_id = fields.Many2one("km.department", string="Department")
+    phone = fields.Char()
+    email = fields.Char()
+    active = fields.Boolean(default=True)
+    patient_ids = fields.One2many("km.patient", "primary_doctor_id", string="Patients")

--- a/odoo_addons/km_hospital/models/patient.py
+++ b/odoo_addons/km_hospital/models/patient.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class KmPatient(models.Model):
+    """Hospital patient."""
+
+    _name = "km.patient"
+    _description = "Patient"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "name"
+
+    patient_code = fields.Char(string="Patient Code", copy=False, index=True, readonly=True)
+    name = fields.Char(required=True, tracking=True)
+    dob = fields.Date(string="Date of Birth")
+    sex = fields.Selection([("m", "Male"), ("f", "Female"), ("o", "Other")])
+    phone = fields.Char()
+    department_id = fields.Many2one("km.department", string="Department")
+    primary_doctor_id = fields.Many2one("km.doctor", string="Primary Doctor")
+    allergies = fields.Text()
+    notes = fields.Text()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("patient_code"):
+                vals["patient_code"] = self.env["ir.sequence"].next_by_code("km.patient") or "/"
+        return super().create(vals_list)

--- a/odoo_addons/km_hospital/models/test.py
+++ b/odoo_addons/km_hospital/models/test.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class KmTest(models.Model):
+    """Lab test definition."""
+
+    _name = "km.test"
+    _description = "Test"
+    _order = "name"
+
+    code = fields.Char()
+    name = fields.Char(required=True)
+    unit = fields.Char()
+    ref_low = fields.Float(string="Ref. Low")
+    ref_high = fields.Float(string="Ref. High")
+    description = fields.Text()

--- a/odoo_addons/km_hospital/models/test_result.py
+++ b/odoo_addons/km_hospital/models/test_result.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class KmTestResult(models.Model):
+    """Result of a lab test."""
+
+    _name = "km.test.result"
+    _description = "Test Result"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "create_date desc"
+
+    appointment_id = fields.Many2one("km.appointment", string="Appointment", required=True)
+    patient_id = fields.Many2one("km.patient", string="Patient", required=True, default=lambda self: self._default_patient())
+    test_id = fields.Many2one("km.test", string="Test", required=True)
+    value = fields.Float()
+    unit = fields.Char()
+    status = fields.Selection(
+        [("draft", "Draft"), ("verified", "Verified")], default="draft", tracking=True
+    )
+
+    def _default_patient(self):
+        appointment = self.env["km.appointment"].browse(self.env.context.get("default_appointment_id"))
+        return appointment.patient_id
+
+    @api.onchange("appointment_id")
+    def _onchange_appointment_id(self):
+        self.patient_id = self.appointment_id.patient_id
+
+    @api.onchange("test_id")
+    def _onchange_test_id(self):
+        self.unit = self.test_id.unit
+
+    def action_verify(self):
+        for rec in self:
+            rec.status = "verified"

--- a/odoo_addons/km_hospital/security/ir.model_access.csv
+++ b/odoo_addons/km_hospital/security/ir.model_access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_km_department_user,km.department,model_km_department,,1,1,1,0
+access_km_doctor_user,km.doctor,model_km_doctor,,1,1,1,0
+access_km_patient_user,km.patient,model_km_patient,,1,1,1,0
+access_km_appointment_user,km.appointment,model_km_appointment,,1,1,1,0
+access_km_test_user,km.test,model_km_test,,1,1,1,0
+access_km_test_result_user,km.test.result,model_km_test_result,,1,1,1,0

--- a/odoo_addons/km_hospital/views/appointment_views.xml
+++ b/odoo_addons/km_hospital/views/appointment_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_appointment_tree" model="ir.ui.view">
+    <field name="name">km.appointment.tree</field>
+    <field name="model">km.appointment</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="name"/>
+        <field name="patient_id"/>
+        <field name="doctor_id"/>
+        <field name="department_id"/>
+        <field name="datetime_start"/>
+        <field name="state"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_appointment_form" model="ir.ui.view">
+    <field name="name">km.appointment.form</field>
+    <field name="model">km.appointment</field>
+    <field name="arch" type="xml">
+      <form string="Appointment">
+        <header>
+          <button name="action_confirm" type="object" string="Confirm" states="draft" class="btn-primary"/>
+          <button name="action_done" type="object" string="Done" states="scheduled" class="btn-primary"/>
+          <button name="action_cancel" type="object" string="Cancel" states="draft,scheduled" class="btn-secondary"/>
+          <field name="state" widget="statusbar" statusbar_visible="draft,scheduled,done,cancelled"/>
+        </header>
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="patient_id"/>
+            <field name="doctor_id"/>
+            <field name="department_id"/>
+            <field name="datetime_start"/>
+            <field name="reason"/>
+          </group>
+        </sheet>
+        <div class="oe_chatter">
+          <field name="message_follower_ids" widget="mail_followers"/>
+          <field name="message_ids" widget="mail_thread"/>
+        </div>
+      </form>
+    </field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/views/department_views.xml
+++ b/odoo_addons/km_hospital/views/department_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_department_tree" model="ir.ui.view">
+    <field name="name">km.department.tree</field>
+    <field name="model">km.department</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="code"/>
+        <field name="name"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_department_form" model="ir.ui.view">
+    <field name="name">km.department.form</field>
+    <field name="model">km.department</field>
+    <field name="arch" type="xml">
+      <form string="Department">
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="code"/>
+            <field name="description"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/views/doctor_views.xml
+++ b/odoo_addons/km_hospital/views/doctor_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_doctor_tree" model="ir.ui.view">
+    <field name="name">km.doctor.tree</field>
+    <field name="model">km.doctor</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="code"/>
+        <field name="name"/>
+        <field name="department_id"/>
+        <field name="phone"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_doctor_form" model="ir.ui.view">
+    <field name="name">km.doctor.form</field>
+    <field name="model">km.doctor</field>
+    <field name="arch" type="xml">
+      <form string="Doctor">
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="code"/>
+            <field name="department_id"/>
+            <field name="phone"/>
+            <field name="email"/>
+            <field name="active"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/views/menu.xml
+++ b/odoo_addons/km_hospital/views/menu.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <menuitem id="km_hospital_menu_root" name="Hospital" sequence="10"/>
+
+  <record id="action_km_departments" model="ir.actions.act_window">
+    <field name="name">Departments</field>
+    <field name="res_model">km.department</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_departments" name="Departments" parent="km_hospital_menu_root" action="action_km_departments" sequence="10"/>
+
+  <record id="action_km_doctors" model="ir.actions.act_window">
+    <field name="name">Doctors</field>
+    <field name="res_model">km.doctor</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_doctors" name="Doctors" parent="km_hospital_menu_root" action="action_km_doctors" sequence="20"/>
+
+  <record id="action_km_patients" model="ir.actions.act_window">
+    <field name="name">Patients</field>
+    <field name="res_model">km.patient</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_patients" name="Patients" parent="km_hospital_menu_root" action="action_km_patients" sequence="30"/>
+
+  <record id="action_km_appointments" model="ir.actions.act_window">
+    <field name="name">Appointments</field>
+    <field name="res_model">km.appointment</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_appointments" name="Appointments" parent="km_hospital_menu_root" action="action_km_appointments" sequence="40"/>
+
+  <record id="action_km_tests" model="ir.actions.act_window">
+    <field name="name">Tests</field>
+    <field name="res_model">km.test</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_tests" name="Tests" parent="km_hospital_menu_root" action="action_km_tests" sequence="50"/>
+
+  <record id="action_km_test_results" model="ir.actions.act_window">
+    <field name="name">Test Results</field>
+    <field name="res_model">km.test.result</field>
+    <field name="view_mode">tree,form</field>
+  </record>
+  <menuitem id="km_hospital_menu_test_results" name="Test Results" parent="km_hospital_menu_root" action="action_km_test_results" sequence="60"/>
+</odoo>

--- a/odoo_addons/km_hospital/views/patient_views.xml
+++ b/odoo_addons/km_hospital/views/patient_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_patient_tree" model="ir.ui.view">
+    <field name="name">km.patient.tree</field>
+    <field name="model">km.patient</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="patient_code"/>
+        <field name="name"/>
+        <field name="department_id"/>
+        <field name="primary_doctor_id"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_patient_form" model="ir.ui.view">
+    <field name="name">km.patient.form</field>
+    <field name="model">km.patient</field>
+    <field name="arch" type="xml">
+      <form string="Patient">
+        <sheet>
+          <group>
+            <field name="patient_code"/>
+            <field name="name"/>
+            <field name="dob"/>
+            <field name="sex"/>
+            <field name="phone"/>
+            <field name="department_id"/>
+            <field name="primary_doctor_id"/>
+            <field name="allergies"/>
+            <field name="notes"/>
+          </group>
+        </sheet>
+        <div class="oe_chatter">
+          <field name="message_follower_ids" widget="mail_followers"/>
+          <field name="message_ids" widget="mail_thread"/>
+        </div>
+      </form>
+    </field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/views/test_result_views.xml
+++ b/odoo_addons/km_hospital/views/test_result_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_test_result_tree" model="ir.ui.view">
+    <field name="name">km.test.result.tree</field>
+    <field name="model">km.test.result</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="appointment_id"/>
+        <field name="patient_id"/>
+        <field name="test_id"/>
+        <field name="value"/>
+        <field name="unit"/>
+        <field name="status"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_test_result_form" model="ir.ui.view">
+    <field name="name">km.test.result.form</field>
+    <field name="model">km.test.result</field>
+    <field name="arch" type="xml">
+      <form string="Test Result">
+        <header>
+          <button name="action_verify" type="object" string="Verify" states="draft" class="btn-primary"/>
+          <field name="status" widget="statusbar" statusbar_visible="draft,verified"/>
+        </header>
+        <sheet>
+          <group>
+            <field name="appointment_id"/>
+            <field name="patient_id"/>
+            <field name="test_id"/>
+            <field name="value"/>
+            <field name="unit"/>
+          </group>
+        </sheet>
+        <div class="oe_chatter">
+          <field name="message_follower_ids" widget="mail_followers"/>
+          <field name="message_ids" widget="mail_thread"/>
+        </div>
+      </form>
+    </field>
+  </record>
+</odoo>

--- a/odoo_addons/km_hospital/views/test_views.xml
+++ b/odoo_addons/km_hospital/views/test_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_km_test_tree" model="ir.ui.view">
+    <field name="name">km.test.tree</field>
+    <field name="model">km.test</field>
+    <field name="arch" type="xml">
+      <tree>
+        <field name="code"/>
+        <field name="name"/>
+        <field name="unit"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_km_test_form" model="ir.ui.view">
+    <field name="name">km.test.form</field>
+    <field name="model">km.test</field>
+    <field name="arch" type="xml">
+      <form string="Test">
+        <sheet>
+          <group>
+            <field name="code"/>
+            <field name="name"/>
+            <field name="unit"/>
+            <field name="ref_low"/>
+            <field name="ref_high"/>
+            <field name="description"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add hospital management models: departments, doctors, patients, appointments, tests and results
- implement sequences, states and verifications
- provide menus, views, security and README

## Testing
- `python -m py_compile $(find odoo_addons/km_hospital -name "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68aad6d46f9883208cf9828343baf3d2