### PR TITLE
Add manual trigger to coding agent workflow

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -3,6 +3,7 @@ name: coding-agent
 on:
   issue_comment:
     types: [created, edited]  # runs when someone comments
+  workflow_dispatch:
 
 permissions:
   contents: write        # create branch & push


### PR DESCRIPTION
## Summary
- allow manual workflow runs via `workflow_dispatch`

## Testing
- `pre-commit run --files .github/workflows/coding-agent.yml` (command not found: pre-commit)


------
https://chatgpt.com/codex/tasks/task_e_68aff131958c8320b19cc80f86ea1cf3