### PR TITLE
Add email field to patient model

### DIFF
--- a/odoo_addons/his_core/models/patient.py
+++ b/odoo_addons/his_core/models/patient.py
@@ -6,3 +6,4 @@ class Patient(models.Model):
 
     name = fields.Char(string='Name', required=True, tracking=True)
     phone = fields.Char(string='Phone', required=True, tracking=True)
+    email = fields.Char(string='Email', tracking=True)


### PR DESCRIPTION
## Summary
- add email field to patient model

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'odoo')

------
https://chatgpt.com/codex/tasks/task_e_68aff423ee80832099afdcfffdd20740